### PR TITLE
grunt v 0.4 task registration as an array

### DIFF
--- a/examples/grunt/Gruntfile.js
+++ b/examples/grunt/Gruntfile.js
@@ -28,5 +28,5 @@ module.exports = function (grunt) {
 
     grunt.loadTasks('../../tasks');
 
-    grunt.registerTask('reload', 'tinylr-start watch');
+    grunt.registerTask('reload', ['tinylr-start', 'watch']);
 };

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ grunt.initConfig({
   }
 });
 
-grunt.registerTask('reload', 'tinylr-start watch');
+grunt.registerTask('reload', ['tinylr-start', 'watch']);
 ```
 
 


### PR DESCRIPTION
Thanks so much for a great project. Exactly what I was looking for--a lightweight reloader to tie into my grunt task based workflow.

I had an issue getting the tiny-lr tasks to run with Grunt v.04, and found the task registration wasn't being passed as an array, but as the v0.3 style of space separated tasks.

I couldn't quite grok your testing scenario for the grunt example, but here's a PR anyhow. 
