### PR TITLE
Use of the default HTTP port when it's not present in the livereload.js URL

### DIFF
--- a/lib/public/livereload.js
+++ b/lib/public/livereload.js
@@ -348,6 +348,8 @@ Options.extract = function(document) {
         options.host = mm[1];
         if (mm[2]) {
           options.port = parseInt(mm[2], 10);
+        } else {
+          options.port = 80;
         }
       }
       if (m[2]) {


### PR DESCRIPTION
I use tiny-lr behind a HTTP reverse proxy which is listening the port 80. It's because I can only use some TCP ports on my company network.

So, I have this html in my webpage :

``` html
<script src="http://myhost:80/livereload.js?snipver=1"></script>
```

Some browsers automatically change http://myhost:80/ to http://myhost/. So livereload.js doesn't detect the port and use 35729 by default. In my opinion, it could be better to use the default HTTP port.

This issue is related to this issue in grunt-contrib-livereload : 
https://github.com/gruntjs/grunt-contrib-livereload/issues/34

For information, here is my reverse proxy configuration with nginx 1.3.15 :

```
location /livereload {
    proxy_pass http://localhost:35729;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "Upgrade";
}
```
