### PR TITLE
onload! and polling! messages should be shown only in verbose mode.

### DIFF
--- a/lib/public/livereload.js
+++ b/lib/public/livereload.js
@@ -686,14 +686,14 @@ Options.extract = function(document) {
         return func();
       };
       clone.onload = function() {
-        console.log("onload!");
+        _this.console.log("onload!");
         _this.knownToSupportCssOnLoad = true;
         return executeCallback();
       };
       if (!this.knownToSupportCssOnLoad) {
         (poll = function() {
           if (clone.sheet) {
-            console.log("polling!");
+            _this.console.log("polling!");
             return executeCallback();
           } else {
             return _this.Timer.start(50, poll);


### PR DESCRIPTION
We don't care about them. It messes console log output.
