### PR TITLE
Add license

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,22 @@
+Copyright (c) 2012-2013 Mickael Daniel
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
   },
   "config": {
     "test_port": "9001"
-  }
+  },
+  "licenses": [{
+    "type": "MIT",
+    "url": "https://github.com/mklabs/tiny-lr/blob/master/LICENSE-MIT"
+  }]
 }


### PR DESCRIPTION
MIT license info (license file and package.json entry) copied from node-fileset, with copyright year update, assuming you would like to continue to use the same license. Fixes #12.
