### PR TITLE
Remove debugging console.log messages

### DIFF
--- a/lib/public/livereload.js
+++ b/lib/public/livereload.js
@@ -686,14 +686,12 @@ Options.extract = function(document) {
         return func();
       };
       clone.onload = function() {
-        console.log("onload!");
         _this.knownToSupportCssOnLoad = true;
         return executeCallback();
       };
       if (!this.knownToSupportCssOnLoad) {
         (poll = function() {
           if (clone.sheet) {
-            console.log("polling!");
             return executeCallback();
           } else {
             return _this.Timer.start(50, poll);


### PR DESCRIPTION
I was surprised to find console messages that look like debugging statements left over. Maybe it's a good idea to remove them or make them opt-in.
