### PR TITLE
Pass tiny-lr options into client to set reload flags

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -5,7 +5,8 @@ var WebSocket = require('faye-websocket');
 
 module.exports = Client;
 
-function Client(req, socket, head) {
+function Client(req, socket, head, options) {
+  options = this.options = options || {};
   this.ws = new WebSocket(req, socket, head);
   this.ws.onmessage = this.message.bind(this);
   this.ws.onclose = this.close.bind(this);
@@ -54,8 +55,9 @@ Client.prototype.reload = function reload(files) {
     this.send({
       command: 'reload',
       path: file,
-      liveCss: true,
-      liveJs: true
+      liveCss: this.options.liveCss !== false,
+      liveJs: this.options.liveJs !== false,
+      liveImg: this.options.liveImg !== false
     });
   }, this);
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -118,7 +118,7 @@ Server.prototype.handle = function handle(req, res, next) {
 
 Server.prototype.websocketify = function websocketify(req, socket, head) {
   var self = this;
-  var client = new Client(req, socket, head);
+  var client = new Client(req, socket, head, this.options);
   this.clients[client.id] = client;
 
   debug('New LiveReload connection (id: %s)', client.id);


### PR DESCRIPTION
The motivation behind this patch is to add the liveImg flag, which is needed when you are using images in canvas or webGL. By default, livereload with liveImg=true will only re-set the src of an image - not reload the whole page, which is not useful if you are creating images dynamically and using them in a different context. Though having flags for liveJs and liveCss seems like a good idea too.
