### PR TITLE
Enable an https lr server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,9 +1,9 @@
-
 var fs        = require('fs');
 var qs        = require('qs');
 var path      = require('path');
 var util      = require('util');
 var http      = require('http');
+var https     = require('https');
 var events    = require('events');
 var parse     = require('url').parse;
 var debug     = require('debug')('tinylr:server');
@@ -11,8 +11,6 @@ var Client    = require('./client');
 var constants = require('constants');
 
 var config = require('../package.json');
-
-module.exports = Server;
 
 function Server(options) {
   options = this.options = options || {};
@@ -32,13 +30,20 @@ function Server(options) {
   this.configure(options.app);
 }
 
+module.exports = Server;
+
 util.inherits(Server, events.EventEmitter);
 
 Server.prototype.configure = function configure(app) {
   debug('Configuring %s', app ? 'connect / express application' : 'HTTP server');
 
   if(!app) {
-    this.server = http.createServer(this.handler.bind(this));
+    if (this.options.key && this.options.cert) {
+      this.server = https.createServer(this.options, this.handler.bind(this));
+    }
+    else {
+      this.server = http.createServer(this.handler.bind(this));
+    }
     this.server.on('upgrade', this.websocketify.bind(this));
     this.server.on('error', this.error.bind(this));
     return this;


### PR DESCRIPTION
By passing the contents of cert files, we can enable an https version of the lr server which is super handy for debugging https.
