### PR TITLE
fix for using livereload.js over https

### DIFF
--- a/lib/public/livereload.js
+++ b/lib/public/livereload.js
@@ -138,9 +138,9 @@ __connector.Connector = Connector = (function() {
     this.WebSocket = WebSocket;
     this.Timer = Timer;
     this.handlers = handlers;
-    if (location.protocol === 'https:') { var wsProtocol = 'wss'; }
-    else { var wsProtocol = 'ws'; }
-    this._uri = wsProtocol + "://" + this.options.host + ":" + this.options.port + "/livereload";
+    if (location.protocol === 'https:') { this.wsProtocol = 'wss'; }
+    else { this.wsProtocol = 'ws'; }
+    this._uri = this.wsProtocol + "://" + this.options.host + ":" + this.options.port + "/livereload";
     this._nextDelay = this.options.mindelay;
     this._connectionDesired = false;
     this.protocol = 0;


### PR DESCRIPTION
We can detect the connection protocol through the global location variable and then set our websocket protocol to either 'wss' or 'ws' accordingly.
