### PR TITLE
Make tiny-lr quieter in operation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -51,7 +51,6 @@ Client.prototype.info = function info(data) {
 
 Client.prototype.reload = function reload(files) {
   files.forEach(function(file) {
-    console.log('... Reload %s ...', file);
     this.send({
       command: 'reload',
       path: file,


### PR DESCRIPTION
I find that it spams the terminal with `... Reload ...` messages.

Was thinking about moving this behind a `quiet`/`silent` option, but perhaps it can just be removed.
