### PR TITLE
Disable livereload in parent frame if present

### DIFF
--- a/lib/public/livereload.js
+++ b/lib/public/livereload.js
@@ -1034,11 +1034,15 @@ __less = LessPlugin = (function() {
 var CustomEvents, LiveReload, k, parent = window;
 CustomEvents = __customevents;
 LiveReload = window.LiveReload = new (__livereload.LiveReload)(window);
-while (parent !== parent.parent) {
-  parent = parent.parent;
-  if (parent.LiveReload !== undefined) {
-    parent.LiveReload.shutDown();
+try {
+  while (parent !== parent.parent) {
+    parent = parent.parent;
+    if (parent.LiveReload !== undefined) {
+      parent.LiveReload.shutDown();
+    }
   }
+} catch (e) {
+  // Mostly a security exception about same-origin problem
 }
 for (k in window) {
   if (k.match(/^LiveReloadPlugin/)) {


### PR DESCRIPTION
When using a tool like [Viewport Resizer](http://lab.maltewassermann.com/viewport-resizer/), livereload is first
injected in the main window, then when we transform this window into an
embedded iframe, we get livereload loaded inside the iframe and outside
the iframe. This means that we will reload both documents on HTML change
and we will get kicked outside our iframe when the main window reload.

This makes using [Viewport Resizer](http://lab.maltewassermann.com/viewport-resizer/) quite difficult. The solution
proposed here is to disable liveloader in the parent frame if
present. Only the inner iframe will keep livereloader.
