### PR TITLE
Use https if 'pfx' option is present

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -38,7 +38,7 @@ Server.prototype.configure = function configure(app) {
   debug('Configuring %s', app ? 'connect / express application' : 'HTTP server');
 
   if(!app) {
-    if (this.options.key && this.options.cert) {
+    if ((this.options.key && this.options.cert) || this.options.pfx) {
       this.server = https.createServer(this.options, this.handler.bind(this));
     }
     else {


### PR DESCRIPTION
`crypto.createCredentials` (and therefore `https.createServer`) can accept a PFX or PKCS12 certificate via the `pfx` option, so tiny-lr should pass this through if provided.

This is especially helpful on Windows, as keys created via `makecert` can be easily exported to PFX.
