### PR TITLE
Update to latest debug release 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "qs": "~0.5.2",
     "faye-websocket": "~0.4.3",
     "noptify": "latest",
-    "debug": "~0.7.0"
+    "debug": "~0.8.0"
   },
   "devDependencies": {
     "mocha": "~1.7.1",


### PR DESCRIPTION
Pretty straight-forward.  I'm in dependency hell right now because tiny-lr requires a specic version of debug, and another module I'm using requires the latest.
