### PR TITLE
Fixed example in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,12 +71,7 @@ var port = 35729;
 
 // tinylr(opts) => new tinylr.Server(opts);
 tinylr().listen(port, function() {
-  if(err) {
-    // deal with err
-    return;
-  }
-
-  console.log('... Listening on %s (pid: %s) ...', port);
+  console.log('... Listening on %s ...', port);
 })
 ```
 


### PR DESCRIPTION
Listen event doesn't receive any parameter.
I also removed the `pid` from console, because that variable doesn't exist and I don't know from where can be got.
