### PR TITLE
Use default port 80/443 if none exists in URL

### DIFF
--- a/lib/public/livereload.js
+++ b/lib/public/livereload.js
@@ -353,6 +353,8 @@ Options.extract = function(document) {
         options.host = mm[1];
         if (mm[2]) {
           options.port = parseInt(mm[2], 10);
+        } else {
+          options.port = options.https ? 443 : 80;
         }
       }
       if (m[2]) {


### PR DESCRIPTION
I want to use tiny-lr behind an nginx proxy on port 80/443. This has two advantages: 1) only ports 80/443 are needed and not port 35729 (firewall, port forwarding, ...). 2) I do not have to configure SSL/HTTPS in tiny-lr because SSL/HTTPS is already configured in nginx.

I'm embedding the livereload.js script like this:

```
<script src="/livereload.js?snipver=1"></script>
```

Unfortunately this does not work out of the box because the livereload.js script fails to notice that it has been loaded over port 80/443. It then falls back to port 35729. The fix is easy: The default port should not be 35729 but 80 or 443 (depending on options.https).

Would this break existing setups? As I understand it: no. If you load livereload.js on a port different from 80/443 then this port is guaranteed to explicitly exist in the URL such that livereload.js would still use it:

```
<script src="http://localhost:35729/livereload.js?snipver=1"></script>
```

proxy setup in nginx configuration:

```
location /livereload {
    proxy_pass http://127.0.0.1:35729;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "Upgrade";
}
```
