### PR TITLE
Use bodyParser.json to remove deprecation warnings

### DIFF
--- a/examples/express/app.js
+++ b/examples/express/app.js
@@ -2,7 +2,6 @@ var fs      = require('fs');
 var path    = require('path');
 var express = require('express');
 var tinylr  = require('../..');
-var body    = require('body-parser');
 var debug   = require('debug')('tinylr:server');
 
 process.env.DEBUG = process.env.DEBUG || 'tinylr*';
@@ -46,6 +45,5 @@ var watch = (function watch(em) {
 
 app
   .use(logger())
-  .use(body())
   .use('/', express.static(path.join(__dirname)))
   .use(tinylr.middleware({ app: app }));

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,7 +11,7 @@ var Client      = require('./client');
 var constants   = require('constants');
 
 // Middleware fallbacks
-var bodyParser  = require('body-parser')()
+var bodyParser  = require('body-parser').json()
 var queryParser = require('./middleware/query')();
 
 var config = require('../package.json');

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -5,7 +5,6 @@ var connect    = require('connect');
 var express    = require('express');
 var request    = require('supertest');
 var debug      = require('debug')('tinylr:test');
-var bodyParser = require('body-parser');
 var Server     = require('..').Server;
 
 var npmenv = process.env;
@@ -23,7 +22,6 @@ function suite(name, app) {return function() {
     this.lr = new Server();
 
     this.app
-      .use(bodyParser())
       .use(this.lr.handler.bind(this.lr));
 
     this.server = http.createServer(this.app);


### PR DESCRIPTION
This change uses the `bodyParser.json()` middleware instead of just using `bodyParser()`, since the latter prints out a deprecation warning to the console telling you that you should use `.json` or `.urlencoded`.

**Warning:** This does remove the ability to use url-encoded data to the server; it all must be JSON data. I am not sure if that is needed or not. The tests all work without it. I can include `bodyParser.urlencoded` if necessary.

Also this removes the `body-parser` middleware from the examples and tests since it is automatically handled in the LR server and does not need to be included in the app middleware. (This also takes care of the deprecation warnings when running them.)
