### PR TITLE
fix: livereload exception in IE9

### DIFF
--- a/lib/public/livereload.js
+++ b/lib/public/livereload.js
@@ -950,6 +950,7 @@ __livereload.LiveReload = LiveReload = (function() {
     var plugin;
     var _this = this;
     if (this.hasPlugin(pluginClass.identifier)) return;
+    if (!this.reloader) return;
     this.pluginIdentifiers[pluginClass.identifier] = true;
     plugin = new pluginClass(this.window, {
       _livereload: this,


### PR DESCRIPTION
> Unable to get value of the property 'addPlugin': object is null or undefined