### PR TITLE
Exit if WebSocket is not supported

### DIFF
--- a/lib/public/livereload.js
+++ b/lib/public/livereload.js
@@ -1072,6 +1072,12 @@ __less = LessPlugin = (function() {
 var CustomEvents, LiveReload, k, parent = window;
 CustomEvents = __customevents;
 LiveReload = window.LiveReload = new (__livereload.LiveReload)(window);
+
+//## No WebSocket support, exit now
+if (!LiveReload.WebSocket){
+  return;
+}
+
 try {
   while (parent !== parent.parent) {
     parent = parent.parent;


### PR DESCRIPTION
On browsers without WebSocket support, exception gets thrown when LiveReload tries to add the LESS plugin.