### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,5 @@
   "config": {
     "test_port": "9001"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/mklabs/tiny-lr/blob/master/LICENSE-MIT"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/