### PR TITLE
Update content type for livereload.js client script file

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -180,6 +180,7 @@ Server.prototype.error = function error(e) {
 // Routes
 
 Server.prototype.livereload = function livereload(req, res) {
+  res.setHeader('Content-Type', 'application/javascript');
   fs.createReadStream(this.options.livereload).pipe(res);
 };
 


### PR DESCRIPTION
This fixes the Content-Type for the client side file `livereload.js` to use `application/javascript` which will cause errors when strict checking is enabled.  Otherwise, some clients will not be able to execute the `livereload.js`.  