### PR TITLE
Set a default port in Server.listen() too

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -147,6 +147,7 @@ Server.prototype.websocketify = function websocketify(req, socket, head) {
 };
 
 Server.prototype.listen = function listen(port, host, fn) {
+  port = parseInt(port || 35729, 10);
   this.port = port;
 
   if (typeof host === 'function') {


### PR DESCRIPTION
This just adds the same behavior that already exists in Server