### PR TITLE
fix listening on unix sockets

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -151,7 +151,9 @@ Server.prototype.websocketify = function websocketify(req, socket, head) {
 };
 
 Server.prototype.listen = function listen(port, host, fn) {
-  port = parseInt(port || 35729, 10);
+  port = port || this.options.port;
+  
+  //Last used port for error display
   this.port = port;
 
   if (typeof host === 'function') {


### PR DESCRIPTION
I know it go back on #80, but that one broke backward compatibility with Unix domain sockets (see [net.Server.listen](https://nodejs.org/api/net.html#net_server_listen_path_callback))

Tried to keep the desired behaviour by using the default port from the constructor.