### PR TITLE
Set host as 127.0.0.1 if host is undefined

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -159,6 +159,8 @@ Server.prototype.listen = function listen(port, host, fn) {
     host = undefined;
   }
 
+  if (!host) host = '127.0.0.1';
+
   this.server.listen(port, host, fn);
 };
 


### PR DESCRIPTION
Only user in localhost can use livereload api.