### PR TITLE
CI: Test on Node.js v0.12.x, v4.x.x, and v5.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
-  - 'iojs'
+  - '5'
+  - '4'
   - '0.12'
   - '0.10'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ version: "{build}"
 # what combinations to test
 environment:
   matrix:
+    - nodejs_version: 5
+    - nodejs_version: 4
     - nodejs_version: 0.12
 
 # Get the latest stable version of Node 0.STABLE.latest


### PR DESCRIPTION
The pull requests replaces the deprecated `iojs` verion of NodeJS with the latest 4.x.x and 5.x.x branches

This pull request changes to use both `4` and `5` aliases with `4` being the latest 4.x.x branch of the LTS version of NodeJS `4.2.4`, and `5` aliasing the latest 5.x.x branch which is currently `5.3.0`

Rather than just the 5.x.x branch, I include 4.x.x because of the [Long Term Support](https://github.com/nodejs/LTS/) of this branch:

![NodeJS LTS Roadmap]
(https://github.com/nodejs/LTS/raw/master/schedule.png)