### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,21 +24,21 @@
     "get-change": "curl http://localhost:35729/changed?files=site.css"
   },
   "dependencies": {
-    "body-parser": "~1.14.0",
+    "body-parser": "~1.14.2",
     "debug": "~2.2.0",
     "faye-websocket": "~0.10.0",
-    "livereload-js": "^2.2.0",
+    "livereload-js": "^2.2.2",
     "parseurl": "~1.3.0",
-    "qs": "~5.1.0"
+    "qs": "~6.0.1"
   },
   "devDependencies": {
     "connect": "^3.4.0",
-    "express": "^4.1.1",
-    "mocha": "^2.3.3",
-    "phantomjs": "^1.9.7-5",
-    "request": "^2.34.0",
+    "express": "^4.13.3",
+    "mocha": "^2.3.4",
+    "phantomjs": "^1.9.19",
+    "request": "^2.67.0",
     "supertest": "^1.1.0",
-    "wd": "^0.3.12"
+    "wd": "^0.4.0"
   },
   "config": {
     "test_port": "9001"

--- a/package.json
+++ b/package.json
@@ -24,20 +24,20 @@
     "get-change": "curl http://localhost:35729/changed?files=site.css"
   },
   "dependencies": {
-    "body-parser": "~1.14.2",
+    "body-parser": "~1.15.0",
     "debug": "~2.2.0",
-    "faye-websocket": "~0.10.0",
+    "faye-websocket": "~0.11.0",
     "livereload-js": "^2.2.2",
-    "parseurl": "~1.3.0",
-    "qs": "~6.0.1"
+    "parseurl": "~1.3.1",
+    "qs": "~5.1.0"
   },
   "devDependencies": {
-    "connect": "^3.4.0",
-    "express": "^4.13.3",
-    "mocha": "^2.3.4",
-    "phantomjs": "^1.9.19",
-    "request": "^2.67.0",
-    "supertest": "^1.1.0",
+    "connect": "^3.4.1",
+    "express": "^4.13.4",
+    "mocha": "^2.4.5",
+    "phantomjs": "^2.1.3",
+    "request": "^2.69.0",
+    "supertest": "^1.2.0",
     "wd": "^0.4.0"
   },
   "config": {


### PR DESCRIPTION
The primary 2 updates are for `qs` and `wd`
• `qs`: `~5.1.0` -> `~6.0.1`
• `wd`: `^0.3.12` -> `^0.4.0`

The remaining are covered by existing semver though when in Rome...