### PR TITLE
Remove unused `liveJs` option

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -54,7 +54,6 @@ Client.prototype.reload = function reload(files) {
       command: 'reload',
       path: file,
       liveCSS: this.options.liveCSS !== false,
-      liveJs: this.options.liveJs !== false,
       liveImg: this.options.liveImg !== false
     });
   }, this);

--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,6 @@ See [gulp-livereload](https://github.com/vohof/gulp-livereload) repo.
 - `cert`          - Option to pass in to create an https server
 - `pfx`           - Can also be used to create an https server instead of `key` & `cert`
 - `liveCSS`       - LiveReload option to enable live CSS reloading (defaults to true)
-- `liveJs`        - LiveReload option to enable live JS reloading (defaults to true)
 - `liveImg`       - LiveReload option to enable live images reloading (defaults to true)
 
 ## Tests


### PR DESCRIPTION
The tiny-lr docs and code reference a `liveJs` option, but there do not appear to be any LiveReload client implementations that do live JS reloading.

This PR removes references to the `liveJs` option. An alternative might be to simply update the README to mention that the `liveJs` option is not supported by (most/all?) livereload clients.

See also https://github.com/mklabs/tiny-lr/issues/107, which discusses `livereactload` (which does offer live JS reloading in very specific circumstances but does not appear to be a full livereload implementation) and [`issue 18 at livereload-js`](https://github.com/livereload/livereload-js/issues/18), which points out that livereload-js does not do live js reloading.

livereload-js currently observes the [`liveCSS` and `liveImg` options](https://github.com/livereload/livereload-js/blob/20e9c3a5a4e33d46f616741394130e93472adc2c/src/livereload.coffee#L93-L94), but not `liveJs`.