### PR TITLE
Use object-assign for Node.js 0.12 support.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,6 @@
-import events    from 'events';
-import WebSocket from 'faye-websocket';
+import events       from 'events';
+import WebSocket    from 'faye-websocket';
+import objectAssign from 'object-assign';
 
 const debug = require('debug')('tinylr:client');
 
@@ -44,12 +45,12 @@ export default class Client extends events.EventEmitter {
   info (data) {
     if (data) {
       debug('Info', data);
-      this.emit('info', Object.assign({}, data, { id: this.id }));
+      this.emit('info', objectAssign({}, data, { id: this.id }));
       this.plugins = data.plugins;
       this.url = data.url;
     }
 
-    return Object.assign({}, data || {}, { id: this.id, url: this.url });
+    return objectAssign({}, data || {}, { id: this.id, url: this.url });
   }
 
   // Server commands

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "debug": "~2.2.0",
     "faye-websocket": "~0.10.0",
     "livereload-js": "^2.2.2",
+    "object-assign": "^4.1.0",
     "qs": "^6.2.0"
   },
   "devDependencies": {
@@ -37,9 +38,9 @@
     "express": "^4.1.1",
     "gaze": "^1.1.2",
     "mocha": "^2.3.3",
+    "npm-watch": "^0.1.6",
     "standard-version": "^2.2.1",
-    "supertest": "^1.2.0",
-    "npm-watch": "^0.1.6"
+    "supertest": "^1.2.0"
   },
   "author": "mklabs",
   "homepage": "https://github.com/mklabs/tiny-lr",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2570,13 +2570,13 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
+object-assign, object-assign@^4.0.1, object-assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
+
 object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
-
-object-assign@^4.0.1, object-assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
 object.omit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Closes #115.

We have a requirement to support Node.js 0.12 in Ember CLI, recent commits in tiny-lr which we adopted broke that. Rather than roll back, here's a PR to add back in Node.js 0.12 support so that we're able to fix forward.

Initial report: https://github.com/ember-cli/ember-cli/issues/6401

Assuming tests pass I'm hoping you can land this and release a new patch version!

Cheers!
Nathan, on behalf of the Ember CLI team.