### PR TITLE
Livereload stream

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -13,13 +13,23 @@ const debug = require('debug')('tinylr:server');
 const CONTENT_TYPE = 'content-type';
 const FORM_TYPE = 'application/x-www-form-urlencoded';
 
+function wrapStream (path) {
+  return function () {
+    return fs.createReadStream(path);
+  };
+}
+
 class Server extends events.EventEmitter {
   constructor (options = {}) {
     super();
 
     this.options = options;
 
-    options.livereload = options.livereload || require.resolve('livereload-js/dist/livereload.js');
+    options.livereload = typeof options.livereload === 'string'
+      ? wrapStream(options.livereload)
+      : typeof options.livereload === 'function'
+        ? options.livereload
+        : wrapStream(require.resolve('livereload-js/dist/livereload.js'));
 
     // todo: change falsy check to allow 0 for random port
     options.port = parseInt(options.port || 35729, 10);
@@ -214,7 +224,7 @@ class Server extends events.EventEmitter {
 
   livereload (req, res) {
     res.setHeader('Content-Type', 'application/javascript');
-    fs.createReadStream(this.options.livereload).pipe(res);
+    this.options.livereload().pipe(res);
   }
 
   changed (req, res) {

--- a/test/helpers/listen.js
+++ b/test/helpers/listen.js
@@ -6,7 +6,7 @@ export default function listen (opts) {
   opts = opts || {};
 
   return function _listen (done) {
-    this.app = new Server();
+    this.app = new Server(opts);
     const srv = this.server = this.app.server;
     const ctx = this;
     this.server.listen(err => {

--- a/test/server-custom-livereload.js
+++ b/test/server-custom-livereload.js
@@ -1,0 +1,120 @@
+import request from 'supertest';
+import assert from 'assert';
+import listen from './helpers/listen';
+import {PassThrough} from 'stream';
+
+describe('tiny-lr', () => {
+  before(listen({
+    livereload: function () {
+      const s = new PassThrough();
+
+      s.end('// custom live-reload');
+
+      return s;
+    }
+  }));
+
+  describe('GET /', () => {
+    it('respond with nothing, but respond', function (done) {
+      request(this.server)
+        .get('/')
+        .expect('Content-Type', /json/)
+        .expect(/\{"tinylr":"Welcome","version":"[\d].[\d].[\d]+"\}/)
+        .expect(200, done);
+    });
+
+    it('unknown route respond with proper 404 and error message', function (done) {
+      request(this.server)
+        .get('/whatev')
+        .expect('Content-Type', /json/)
+        .expect('{"error":"not_found","reason":"no such route"}')
+        .expect(404, done);
+    });
+  });
+
+  describe('GET /changed', () => {
+    it('with no clients, no files', function (done) {
+      request(this.server)
+        .get('/changed')
+        .expect('Content-Type', /json/)
+        .expect(/"clients":\[\]/)
+        .expect(/"files":\[\]/)
+        .expect(200, done);
+    });
+
+    it('with no clients, some files', function (done) {
+      request(this.server)
+        .get('/changed?files=gonna.css,test.css,it.css')
+        .expect('Content-Type', /json/)
+        .expect('{"clients":[],"files":["gonna.css","test.css","it.css"]}')
+        .expect(200, done);
+    });
+  });
+
+  describe('POST /changed', () => {
+    it('with no clients, no files', function (done) {
+      request(this.server)
+        .post('/changed')
+        .expect('Content-Type', /json/)
+        .expect(/"clients":\[\]/)
+        .expect(/"files":\[\]/)
+        .expect(200, done);
+    });
+
+    it('with no clients, some files', function (done) {
+      const data = { clients: [], files: ['cat.css', 'sed.css', 'ack.js'] };
+
+      request(this.server)
+        .post('/changed')
+        // .type('json')
+        .send({ files: data.files })
+        .expect('Content-Type', /json/)
+        .expect(JSON.stringify(data))
+        .expect(200, done);
+    });
+  });
+
+  describe('POST /alert', () => {
+    it('with no clients, no message', function (done) {
+      const data = { clients: [] };
+      request(this.server)
+        .post('/alert')
+        .expect('Content-Type', /json/)
+        .expect(JSON.stringify(data))
+        .expect(200, done);
+    });
+
+    it('with no clients, some message', function (done) {
+      const message = 'Hello Client!';
+      const data = { clients: [], message: message };
+      request(this.server)
+        .post('/alert')
+        .send({ message: message })
+        .expect('Content-Type', /json/)
+        .expect(JSON.stringify(data))
+        .expect(200, done);
+    });
+  });
+
+  describe('GET /livereload.js', () => {
+    it('respond with livereload script', function (done) {
+      request(this.server)
+        .get('/livereload.js')
+        .expect('// custom live-reload')
+        .expect(200, done);
+    });
+  });
+
+  describe('GET /kill', () => {
+    it('shutdown the server', function (done) {
+      const srv = this.server;
+      request(srv)
+        .get('/kill')
+        .expect(200, err => {
+          if (err) return done(err);
+          assert.ok(!srv._handle);
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
I realise this might not be something you're after, but maybe we can find common ground and have a feature that leaves more flexibility.

I want to bundle livereload on the fly with browserify as I've got some extra plugins that go with the stock version. Allowing one to pass a function that returns a stream was the least invasive solution I could come up with, that was also easy to code. I don't know if you have plans for a similar feature, but implemented differently? I'd be open to do the work, if we can find a solution that everyone is happy with.

This PR should be semver minor, as it preserves the existing API but also checks for `opts.livereload` being a function.