### PR TITLE
Call method instead of .apply, fixes #120

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -154,7 +154,7 @@ class Server extends events.EventEmitter {
     socket.on('error', (e) => {
       // ignore frequent ECONNRESET error (seems inevitable when refresh)
       if (e.code === 'ECONNRESET') return;
-      this.error.apply(this, e);
+      this.error.call(this, e);
     });
 
     client.once('info', (data) => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -154,7 +154,7 @@ class Server extends events.EventEmitter {
     socket.on('error', (e) => {
       // ignore frequent ECONNRESET error (seems inevitable when refresh)
       if (e.code === 'ECONNRESET') return;
-      this.error.call(this, e);
+      this.error(e);
     });
 
     client.once('info', (data) => {


### PR DESCRIPTION
In javascript `Function.prototype.apply()` expects an array as second argument. However, at the moment the error object instead of an array is passed to the `apply` method. So in this case, `Function.prototype.call()` makes for sense than `apply()`, because then you can pass arguments directly.