### PR TITLE
Update `debug` dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "body": "^5.1.0",
-    "debug": "~2.2.0",
+    "debug": "~2.6.7",
     "faye-websocket": "~0.10.0",
     "livereload-js": "^2.2.2",
     "object-assign": "^4.1.0",


### PR DESCRIPTION
Addresses https://snyk.io/vuln/npm:ms:20170412 by way of an upgraded
`ms` dependency.

Tracking: https://github.com/digitalbazaar/bedrock-test/pull/3