### PR TITLE
Allow error(undefined)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -200,7 +200,7 @@ class Server extends events.EventEmitter {
     }
 
     console.error();
-    if( typeof e === "undefined" ) {
+    if (typeof e === 'undefined') {
       console.error('... Uhoh. Got error %s ...', e);
     } else {
       console.error('... Uhoh. Got error %s ...', e.message);

--- a/lib/server.js
+++ b/lib/server.js
@@ -200,14 +200,18 @@ class Server extends events.EventEmitter {
     }
 
     console.error();
-    console.error('... Uhoh. Got error %s ...', e.message);
-    console.error(e.stack);
+    if( typeof e === "undefined" ) {
+      console.error('... Uhoh. Got error %s ...', e);
+    } else {
+      console.error('... Uhoh. Got error %s ...', e.message);
+      console.error(e.stack);
 
-    if (e.code !== 'EADDRINUSE') return;
-    console.error();
-    console.error('You already have a server listening on %s', this.port);
-    console.error('You should stop it and try again.');
-    console.error();
+      if (e.code !== 'EADDRINUSE') return;
+      console.error();
+      console.error('You already have a server listening on %s', this.port);
+      console.error('You should stop it and try again.');
+      console.error();
+    }
   }
 
   // Routes


### PR DESCRIPTION
Using `ionic serve` occasionally crashes with output that calls for this fix, e.g.:

```
/full/path/to/project/node_modules/tiny-lr/src/server.js:266
      console.error('... Uhoh. Got error %s ...', e.message);
                                                   ^

TypeError: Cannot read property 'message' of undefined
```