### PR TITLE
Fix changed done callback, missing typeof.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ function middleware (opts) {
 // Changed helper, helps with notifying the server of a file change
 function changed (done) {
   const files = [].slice.call(arguments);
-  if (files[files.length - 1] === 'function') done = files.pop();
+  if (typeof files[files.length - 1] === 'function') done = files.pop();
   done = typeof done === 'function' ? done : () => {};
   debug('Notifying %d servers - Files: ', servers.length, files);
   servers.forEach(srv => {


### PR DESCRIPTION
The missing `typeof` prevents the `done` callback from ever firing. This pull request fixes that.